### PR TITLE
Support Reduct Storage HTTP API v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed:
+
+- Deprecated entry `list` function, [PR-42](https://github.com/reduct-storage/reduct-py/pull/42)
+
+### Added:
+
+- `/api/v1/` prefix to all http endpoints, [PR-42](https://github.com/reduct-storage/reduct-py/pull/42)
+
 ## [0.5.1] - 2022-09-14
 
 ### Removed:

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -247,34 +247,6 @@ class Bucket:
             content_length=content_length if content_length is not None else len(data),
         )
 
-    @deprecated(
-        deprecated_in="0.4.0", removed_in="1.0.0", details="Use Bucket.query instead"
-    )
-    async def list(
-        self, entry_name: str, start: int, stop: int
-    ) -> List[Tuple[int, int]]:
-        """
-        Get a list of records in an entry for a specified time interval
-        Args:
-            entry_name: name of entry in the bucket
-            start: the beginning of the time interval
-            stop: the end of the time interval
-        Raises:
-            ReductError: if there is an HTTP error
-        Returns:
-            List[Tuple[int,int]]:  list of tuples, where each tuple
-            has time stamp (first element) of a record and its size in bytes
-        """
-        params = {"start": start, "stop": stop}
-        data = await self._http.request_all(
-            "GET",
-            f"/b/{self.name}/{entry_name}/list",
-            params=params,
-        )
-        records = json.loads(data)["records"]
-        items = [(int(record["ts"]), int(record["size"])) for record in records]
-        return items
-
     async def query(
         self,
         entry_name: str,

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -6,14 +6,12 @@ from enum import Enum
 from typing import (
     Optional,
     List,
-    Tuple,
     AsyncIterator,
     Union,
     Callable,
     Awaitable,
 )
 
-from deprecation import deprecated
 from pydantic import BaseModel
 
 from reduct.http import HttpClient

--- a/pkg/reduct/http.py
+++ b/pkg/reduct/http.py
@@ -8,13 +8,16 @@ from aiohttp import ClientTimeout, ClientResponse
 from reduct.error import ReductError
 
 
+API_PREFIX = "/api/v1/"
+
+
 class HttpClient:
     """Wrapper for HTTP calls"""
 
     def __init__(
         self, url: str, api_token: Optional[str] = None, timeout: Optional[float] = None
     ):
-        self.url = url
+        self.url = url + API_PREFIX
         self.api_token = api_token
         self.headers = (
             {"Authorization": f"Bearer {api_token}"} if api_token is not None else {}

--- a/pkg/reduct/http.py
+++ b/pkg/reduct/http.py
@@ -8,7 +8,7 @@ from aiohttp import ClientTimeout, ClientResponse
 from reduct.error import ReductError
 
 
-API_PREFIX = "/api/v1/"
+API_PREFIX = "/api/v1"
 
 
 class HttpClient:

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -133,13 +133,6 @@ async def test__write_by_chunks(bucket_2):
 
 
 @pytest.mark.asyncio
-async def test__list(bucket_1):
-    """Should get list of records for time interval"""
-    records = await bucket_1.list("entry-2", start=0, stop=5_000_000)
-    assert records == [(3000000, 11), (4000000, 11)]
-
-
-@pytest.mark.asyncio
 async def test_query_records(bucket_1):
     """Should query records for a time interval"""
     records: List[Record] = [


### PR DESCRIPTION
Closes #42

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bring features in line with Reduct v1.0.0

### What is the current behavior?

See #42

### What is the new behavior?

Removed deprecated entry `list` function and added `/api/v1/` as API prefix


### Does this PR introduce a breaking change?

It removes the entry list function. It requires Reduct release v1.0.0, since the API is now moved to `/api/v1/*`.

### Other information:
