### PR TITLE
Fix for issue `reduct-py-40`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 pkg/reduct/VERSION
 *.egg-info
+.venv
+.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed:
-
-- Deprecated entry `list` function, [PR-42](https://github.com/reduct-storage/reduct-py/pull/42)
-
 ### Added:
 
 - `/api/v1/` prefix to all http endpoints, [PR-42](https://github.com/reduct-storage/reduct-py/pull/42)
+
+### Changed:
+
+- `bucket.read()` now returns a Record yielded from an asynccontext, [PR-43](https://github.com/reduct-storage/reduct-py/pull/43)
+
+### Removed:
+
+- Deprecated entry `list` function, [PR-42](https://github.com/reduct-storage/reduct-py/pull/42)
+- `bucket.read_by` method, [PR-43](https://github.com/reduct-storage/reduct-py/pull/43)
 
 ## [0.5.1] - 2022-09-14
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ async def main():
 
     ts = time.time_ns() / 1000
     await bucket.write("entry-1", b"Hey!!", ts)
-    data = await bucket.read("entry-1", ts)
-    print(data)
+    async with bucket.read("entry-1", ts) as record:
+        data = await record.read_all()
+        print(data)
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -183,7 +183,7 @@ class Bucket:
             timestamp = int(resp.headers["x-reduct-time"])
             size = int(resp.headers["content-length"])
 
-            yield Record(
+            return Record(
                 timestamp=timestamp,
                 size=size,
                 last=True,

--- a/pkg/reduct/http.py
+++ b/pkg/reduct/http.py
@@ -25,7 +25,9 @@ class HttpClient:
         self.timeout = ClientTimeout(timeout)
 
     @asynccontextmanager
-    async def request(self, method: str, path: str = "", **kwargs) -> ClientResponse:
+    async def request(
+        self, method: str, path: str = "", **kwargs
+    ) -> AsyncIterator[ClientResponse]:
         """HTTP request with ReductError exception"""
 
         extra_headers = {}

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -79,35 +79,26 @@ async def test__get_entries(bucket_1):
 @pytest.mark.asyncio
 async def test__read_by_timestamp(bucket_1):
     """Should read a record by timestamp"""
-    record: Record = await bucket_1.read("entry-2", timestamp=3_000_000)
-    data = await record.read_all()
-    assert data == b"some-data-3"
+    async with bucket_1.read("entry-2", timestamp=3_000_000) as record:
+        data = await record.read_all()
+        assert data == b"some-data-3"
 
 
 @pytest.mark.asyncio
 async def test__read_latest(bucket_1):
     """Should read the latest record if no timestamp"""
-    record = await bucket_1.read("entry-2")
-    # data = await record.read_all()
-    assert record == b"some-data-4"
-
-
-@pytest.mark.asyncio
-async def test__read_by_chunks(bucket_1):
-    """Should read by chunks"""
-    data = b""
-    async for chunk in bucket_1.read_by("entry-2", chunk_size=3):
-        data += chunk
-
-    assert data == b"some-data-4"
+    async with bucket_1.read("entry-2") as record:
+        data = await record.read_all()
+        assert data == b"some-data-4"
 
 
 @pytest.mark.asyncio
 async def test__write_by_timestamp(bucket_2):
     """Should write a record by timestamp"""
     await bucket_2.write("entry-3", b"test-data", timestamp=5_000_000)
-    data = await bucket_2.read("entry-3", timestamp=5_000_000)
-    assert data == b"test-data"
+    async with bucket_2.read("entry-3", timestamp=5_000_000) as record:
+        data = await record.read_all()
+        assert data == b"test-data"
 
 
 @pytest.mark.asyncio
@@ -117,8 +108,9 @@ async def test__write_with_current_time(bucket_2):
 
     await bucket_2.write("entry-3", b"test-data")
     await bucket_2.write("entry-3", b"old-data", timestamp=belated_timestamp)
-    data = await bucket_2.read("entry-3")
-    assert data == b"test-data"
+    async with bucket_2.read("entry-3") as record:
+        data = await record.read_all()
+        assert data == b"test-data"
 
 
 @pytest.mark.asyncio
@@ -130,8 +122,9 @@ async def test__write_by_chunks(bucket_2):
             yield chunk
 
     await bucket_2.write("entry-1", sender(), content_length=10)
-    data = await bucket_2.read("entry-1")
-    assert data == b"part1part2"
+    async with bucket_2.read("entry-1") as record:
+        data = await record.read_all()
+        assert data == b"part1part2"
 
 
 @pytest.mark.asyncio

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -79,15 +79,17 @@ async def test__get_entries(bucket_1):
 @pytest.mark.asyncio
 async def test__read_by_timestamp(bucket_1):
     """Should read a record by timestamp"""
-    data = await bucket_1.read("entry-2", timestamp=3_000_000)
+    record: Record = await bucket_1.read("entry-2", timestamp=3_000_000)
+    data = await record.read_all()
     assert data == b"some-data-3"
 
 
 @pytest.mark.asyncio
 async def test__read_latest(bucket_1):
     """Should read the latest record if no timestamp"""
-    data = await bucket_1.read("entry-2")
-    assert data == b"some-data-4"
+    record = await bucket_1.read("entry-2")
+    # data = await record.read_all()
+    assert record == b"some-data-4"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #40

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

- Changes the interface of `bucket.read` to return `Record`s inside an `asynccontext`. 
- Removes the `bucket.read_by` method, which has been functionally replaced by `bucket.query`.

### What is the current behavior?

Currently `read` and `read_by` return raw bytes.

### What is the new behavior?

`read` now returns a Record, which has object metadata, along with async methods to retrieve the raw data either entirely or iteratively as chunks. 


### Does this PR introduce a breaking change?

- `bucket.read_by` has been removed
- `bucket.read` now returns a `Record`

### Other information:
