### PR TITLE
No detail in ReductError exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed:
 
-- `client.get_bucket` now uses `GET` instead of `HEAD` in order to be able to return a meaningful error to the user.
+- `client.get_bucket` now uses `GET` instead of `HEAD` in order to be able to return a meaningful error to the user, [PR-51](https://github.com/reduct-storage/reduct-py/pull/51)
 
 ## [v1.0.0] - 2022-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed:
+
+- `client.get_bucket` now uses `GET` instead of `HEAD` in order to be able to return a meaningful error to the user.
+
 ## [v1.0.0] - 2022-10-18
 
 ### Added:

--- a/pkg/reduct/client.py
+++ b/pkg/reduct/client.py
@@ -101,7 +101,7 @@ class Client:
         Raises:
             ReductError: if there is an HTTP error
         """
-        await self._http.request_all("HEAD", f"/b/{name}")
+        await self._http.request_all("GET", f"/b/{name}")
         return Bucket(name, self._http)
 
     async def create_bucket(

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -108,8 +108,9 @@ async def test__get_bucket(client):
 @pytest.mark.asyncio
 async def test__get_bucket_with_error(client):
     """Should raise an error, if bucket doesn't exist"""
-    with pytest.raises(ReductError):
+    with pytest.raises(ReductError) as reduct_err:
         await client.get_bucket("NOTEXIST")
+    assert "Status 404: Bucket 'NOTEXIST' is not found" == str(reduct_err.value)
 
 
 def test__exception_formatting():


### PR DESCRIPTION
Closes #50 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Uses `HEAD` to discover bucket existence, but on error gets no error message since `HEAD` returns no body.

### What is the new behavior?

Uses `GET` to discover bucket existence, so that we can use the error message from the response body.

### Does this PR introduce a breaking change?

Nope.

### Other information:
