### PR TITLE
Hide internal dependency exceptions with ReductErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed:
 
-- `client.get_bucket` now uses `GET` instead of `HEAD` in order to be able to return a meaningful error to the user, [PR-51](https://github.com/reduct-storage/reduct-py/pull/51)
+- `Client.get_bucket` now uses `GET` instead of `HEAD` in order to be able to return a meaningful error to the user, [PR-51](https://github.com/reduct-storage/reduct-py/pull/51)
+- `Client` class now catches parsing errors raised by incorrect server configurations or missing servers, [PR-52](https://github.com/reduct-storage/reduct-py/pull/52)
 
 ## [v1.0.0] - 2022-10-18
 

--- a/pkg/reduct/client.py
+++ b/pkg/reduct/client.py
@@ -61,8 +61,8 @@ class Client:
             timeout: total timeout for connection, request and response in seconds
 
         Examples:
-        >>> client = Client("http://127.0.0.1:8383")
-        >>> info = await client.info()
+            >>> client = Client("http://127.0.0.1:8383")
+            >>> info = await client.info()
         """
         self._http = HttpClient(url.rstrip("/"), api_token, timeout)
 

--- a/pkg/reduct/client.py
+++ b/pkg/reduct/client.py
@@ -61,8 +61,8 @@ class Client:
             timeout: total timeout for connection, request and response in seconds
 
         Examples:
-            >>> client = Client("http://127.0.0.1:8383")
-            >>> info = await client.info()
+        >>> client = Client("http://127.0.0.1:8383")
+        >>> info = await client.info()
         """
         self._http = HttpClient(url.rstrip("/"), api_token, timeout)
 

--- a/pkg/reduct/error.py
+++ b/pkg/reduct/error.py
@@ -1,5 +1,5 @@
 """Reduct Errors"""
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 
 class ServerError(BaseModel):
@@ -13,7 +13,14 @@ class ReductError(Exception):
 
     def __init__(self, code: int, message: str):
         self._code = code
-        self.message = ServerError.parse_raw(message).detail if message else ""
+
+        try:
+            self.message = ServerError.parse_raw(message).detail if message else ""
+        except ValidationError:
+            self.message = (
+                "Could not parse error response from server, is it definitely Reduct?"
+            )
+
         super().__init__(f"Status {self._code}: {self.message}")
 
     @property

--- a/pkg/reduct/http.py
+++ b/pkg/reduct/http.py
@@ -51,10 +51,12 @@ class HttpClient:
                     else:
                         raise ReductError(response.status, await response.text())
             except ClientConnectorError:
-                # pylint: disable=line-too-long
                 raise ReductError(
                     599,
-                    f'{{"detail": "Connection failed, server {self.url} cannot be reached"}}',
+                    (
+                        f'{{"detail": "Connection failed,'
+                        f'server {self.url} cannot be reached"}}'
+                    ),
                 ) from None
 
     async def request_all(self, method: str, path: str = "", **kwargs) -> bytes:

--- a/pkg/reduct/http.py
+++ b/pkg/reduct/http.py
@@ -51,6 +51,7 @@ class HttpClient:
                     else:
                         raise ReductError(response.status, await response.text())
             except ClientConnectorError:
+                # pylint: disable=line-too-long
                 raise ReductError(
                     599,
                     f'{{"detail": "Connection failed, server {self.url} cannot be reached"}}',

--- a/pkg/reduct/http.py
+++ b/pkg/reduct/http.py
@@ -4,6 +4,7 @@ from typing import Optional, AsyncIterator
 
 import aiohttp
 from aiohttp import ClientTimeout, ClientResponse
+from aiohttp.client_exceptions import ClientConnectorError
 
 from reduct.error import ReductError
 
@@ -36,18 +37,24 @@ class HttpClient:
             del kwargs["content_length"]
 
         async with aiohttp.ClientSession(timeout=self.timeout) as session:
-            async with session.request(
-                method,
-                f"{self.url}{path.strip()}",
-                headers=dict(self.headers, **extra_headers),
-                **kwargs,
-            ) as response:
+            try:
+                async with session.request(
+                    method,
+                    f"{self.url}{path.strip()}",
+                    headers=dict(self.headers, **extra_headers),
+                    **kwargs,
+                ) as response:
 
-                if response.ok:
-                    yield response
+                    if response.ok:
+                        yield response
 
-                else:
-                    raise ReductError(response.status, await response.text())
+                    else:
+                        raise ReductError(response.status, await response.text())
+            except ClientConnectorError:
+                raise ReductError(
+                    599,
+                    f'{{"detail": "Connection failed, server {self.url} cannot be reached"}}',
+                ) from None
 
     async def request_all(self, method: str, path: str = "", **kwargs) -> bytes:
         """Http request"""

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -20,7 +20,7 @@ async def test__bad_url():
     """Should raise an error"""
     client = Client("http://127.0.0.1:65535")
 
-    with pytest.raises(ClientConnectionError):
+    with pytest.raises(ReductError, match="Connection failed"):
         await client.info()
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -3,7 +3,6 @@ from asyncio import sleep
 from typing import List
 
 import pytest
-from aiohttp import ClientConnectionError
 
 from reduct import (
     Client,
@@ -31,9 +30,9 @@ async def test__bad_url_server_exists():
 
     with pytest.raises(ReductError) as reduct_err:
         await client.info()
-    assert (
-        str(reduct_err.value)
-        == "Status 404: Could not parse error response from server, is it definitely Reduct?"
+    assert str(reduct_err.value) == (
+        "Status 404: Could not parse error response from server,"
+        " is it definitely Reduct?"
     )
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -23,13 +23,18 @@ async def test__bad_url():
     with pytest.raises(ClientConnectionError):
         await client.info()
 
+
 @pytest.mark.asyncio
 async def test__bad_url_server_exists():
     """Should raise an error"""
     client = Client("http://example.com")
 
-    with pytest.raises(ReductError):
+    with pytest.raises(ReductError) as reduct_err:
         await client.info()
+    assert (
+        str(reduct_err.value)
+        == "Status 404: Could not parse error response from server, is it definitely Reduct?"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -23,6 +23,14 @@ async def test__bad_url():
     with pytest.raises(ClientConnectionError):
         await client.info()
 
+@pytest.mark.asyncio
+async def test__bad_url_server_exists():
+    """Should raise an error"""
+    client = Client("http://example.com")
+
+    with pytest.raises(ReductError):
+        await client.info()
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("bucket_1", "bucket_2")


### PR DESCRIPTION
Closes #47

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Catch additional errors and raise `ReductErrors` instead.

To fail and expose underlying library errors. This is difficult for users to catch.
https://github.com/reduct-storage/reduct-py/issues/47

### What is the new behavior?

Raise ReductErrors instead.


### Does this PR introduce a breaking change?

No.

### Other information:
