### PR TITLE
Sync query link creation with record identity API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Sync query link creation with record identity API by resolving `record_index` to `record_entry` + `record_timestamp`, preserving legacy `index` compatibility, and adding record-index validation/tests, [PR-167](https://github.com/reductstore/reduct-py/pull/167)
+
 ## 1.19.0 - 2026-04-07
 
 ### Added

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -685,6 +685,13 @@ class Bucket:  # pylint: disable=too-many-public-methods
         stop = unix_timestamp_from_any(stop) if stop else None
 
         record_index = kwargs.get("record_index", 0)
+        if record_index is not None and (
+            not isinstance(record_index, int)
+            or isinstance(record_index, bool)
+            or record_index < 0
+        ):
+            raise ValueError("record_index must be a non-negative integer")
+
         expire_at: datetime | None = kwargs.get("expire_at", None)
 
         if expire_at is None:
@@ -699,10 +706,23 @@ class Bucket:  # pylint: disable=too-many-public-methods
             only_metadata=False,
         )
 
+        record_entry = None
+        record_timestamp = None
+        if record_index is not None:
+            record_entry, record_timestamp = await self._resolve_record_identity(
+                entries,
+                record_index,
+                start,
+                stop,
+                when,
+            )
+
         query_link_params = CreateQueryLinkRequest(
             bucket=self.name,
             entry=entries if isinstance(entries, str) else "",
             index=record_index,
+            record_entry=record_entry,
+            record_timestamp=record_timestamp,
             query=query_message,
             expire_at=int(expire_at.timestamp()),
             base_url=kwargs.get("base_url", None),
@@ -725,11 +745,35 @@ class Bucket:  # pylint: disable=too-many-public-methods
         body, _ = await self._http.request_all(
             "POST",
             f"/links/{file_name}",
-            data=query_link_params.model_dump_json(),
+            data=query_link_params.model_dump_json(exclude_none=True),
             content_type="application/json",
         )
 
         return CreateQueryLinkResponse.model_validate_json(body).link
+
+    async def _resolve_record_identity(
+        self,
+        entries: str | list[str],
+        record_index: int,
+        start: int | None,
+        stop: int | None,
+        when: dict | None,
+    ) -> tuple[str | None, int | None]:
+        """Resolve an indexed record to exact entry + timestamp identity."""
+
+        current_index = 0
+        async for record in self.query(
+            entries,
+            start=start,
+            stop=stop,
+            when=when,
+            head=True,
+        ):
+            if current_index == record_index:
+                return record.entry, record.timestamp
+            current_index += 1
+
+        return None, None
 
     async def write_attachments(self, entry_name: str, attachments: dict[str, dict]):
         """

--- a/pkg/reduct/msg/bucket.py
+++ b/pkg/reduct/msg/bucket.py
@@ -153,6 +153,10 @@ class CreateQueryLinkRequest(BaseModel):
     """entry name"""
     index: Optional[int] = None
     """record index"""
+    record_entry: Optional[str] = None
+    """resolved entry name for the indexed record"""
+    record_timestamp: Optional[int] = None
+    """resolved UNIX timestamp in microseconds for the indexed record"""
     query: QueryEntry
     """query"""
     expire_at: int = None

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -1,6 +1,7 @@
 """Tests for Bucket"""
 
 import asyncio
+import json
 import time
 from datetime import datetime, timedelta
 
@@ -821,6 +822,38 @@ async def test_create_query_multi_entry(bucket_1):
     assert resp.headers["x-reduct-time"] == "2000000"
     assert resp.headers["x-reduct-entry"] == "entry-1"
     assert resp.headers["x-reduct-label-number"] == "2"
+
+
+@pytest.mark.asyncio
+@requires_api("1.19")
+# pylint: disable=protected-access
+async def test_create_query_link_record_identity_payload(bucket_1, monkeypatch):
+    """Should include resolved record identity in query link payload"""
+
+    captured_payload = {}
+    original_request_all = bucket_1._http.request_all
+
+    async def request_all_with_capture(method, path, **kwargs):
+        if method == "POST" and path.startswith("/links/"):
+            captured_payload.update(json.loads(kwargs["data"]))
+        return await original_request_all(method, path, **kwargs)
+
+    monkeypatch.setattr(bucket_1._http, "request_all", request_all_with_capture)
+
+    await bucket_1.create_query_link("entry-2", record_index=1)
+
+    assert captured_payload["index"] == 1
+    assert captured_payload["record_entry"] == "entry-2"
+    assert captured_payload["record_timestamp"] == 4000000
+
+
+@pytest.mark.asyncio
+@requires_api("1.17")
+async def test_create_query_link_invalid_record_index(bucket_1):
+    """Should validate record index argument"""
+
+    with pytest.raises(ValueError, match="record_index must be a non-negative integer"):
+        await bucket_1.create_query_link("entry-2", record_index=-1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #166

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature parity / compatibility update for query-link creation.

### What was changed?

- Added `record_entry` and `record_timestamp` fields to `CreateQueryLinkRequest`.
- Updated `Bucket.create_query_link` to:
  - validate `record_index` as a non-negative integer,
  - resolve `record_index` to exact record identity (`entry` + `timestamp`) via metadata query,
  - include resolved identity in query-link payload,
  - continue sending legacy `index` for backward compatibility.
- Added tests:
  - payload includes `record_entry` and `record_timestamp`,
  - invalid `record_index` raises a clear error.

### Related issues

- https://github.com/reductstore/reduct-py/issues/166
- https://github.com/reductstore/reduct-js/pull/167
- https://github.com/reductstore/reductstore/issues/1332

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run:
- `pytest tests/bucket_test.py -k "create_query_link_record_index or create_query_multi_entry or create_query_link_record_identity_payload or create_query_link_invalid_record_index"`
  - `reduct/store:main`: 4 passed
  - `reduct/store:latest`: 3 passed, 1 skipped (`requires_api("1.19")`)
- `pylint pkg/reduct/bucket.py pkg/reduct/msg/bucket.py tests/bucket_test.py`
- `black --check pkg/reduct/bucket.py pkg/reduct/msg/bucket.py tests/bucket_test.py`


### Approved plan reference

- Plan comment: https://github.com/reductstore/reduct-py/issues/166#issuecomment-4269545507
- Approval: https://github.com/reductstore/reduct-py/issues/166#issuecomment-4278395515