### PR TITLE
Fix create_query_link selector flow for API v1.19+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Sync query link creation with record identity API without client-side resolution: use legacy `record_index` only for pre-1.19 servers, and use explicit `record_entry` + `record_timestamp` for API v1.19+, [PR-167](https://github.com/reductstore/reduct-py/pull/167)
+- Sync query link creation with record identity API without client-side resolution: use legacy `record_index` only for pre-1.19 servers, and use explicit `record_entry` + `record_timestamp` for API v1.19+, [PR-168](https://github.com/reductstore/reduct-py/pull/168)
 
 ## 1.19.0 - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Sync query link creation with record identity API by resolving `record_index` to `record_entry` + `record_timestamp`, preserving legacy `index` compatibility, and adding record-index validation/tests, [PR-167](https://github.com/reductstore/reduct-py/pull/167)
+- Sync query link creation with record identity API without client-side resolution: use legacy `record_index` only for pre-1.19 servers, and use explicit `record_entry` + `record_timestamp` for API v1.19+, [PR-167](https://github.com/reductstore/reduct-py/pull/167)
 
 ## 1.19.0 - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.19.1 - 2026-04-20
+
 ### Fixed
 
 - Sync query link creation with record identity API without client-side resolution: use legacy `record_index` only for pre-1.19 servers, and use explicit `record_entry` + `record_timestamp` for API v1.19+, [PR-168](https://github.com/reductstore/reduct-py/pull/168)

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -8,6 +8,7 @@ import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from functools import partial
+from glob import has_magic
 from typing import (
     AsyncIterator,
     Any,
@@ -687,6 +688,7 @@ class Bucket:  # pylint: disable=too-many-public-methods
         start = unix_timestamp_from_any(start) if start else None
         stop = unix_timestamp_from_any(stop) if stop else None
 
+        kwargs = self._with_default_record_entry(entries, kwargs)
         record_index, record_entry, record_timestamp = self._parse_query_link_selector(
             kwargs
         )
@@ -729,6 +731,24 @@ class Bucket:  # pylint: disable=too-many-public-methods
         )
 
         return CreateQueryLinkResponse.model_validate_json(body).link
+
+    @staticmethod
+    def _with_default_record_entry(
+        entries: str | list[str], kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        if "record_entry" in kwargs or "record_timestamp" not in kwargs:
+            return kwargs
+
+        default_record_entry: str | None = None
+        if isinstance(entries, str):
+            default_record_entry = entries
+        elif len(entries) == 1:
+            default_record_entry = entries[0]
+
+        if default_record_entry is None or has_magic(default_record_entry):
+            return kwargs
+
+        return {**kwargs, "record_entry": default_record_entry}
 
     def _parse_query_link_selector(
         self, kwargs: dict[str, Any]

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -672,10 +672,13 @@ class Bucket:  # pylint: disable=too-many-public-methods
             start: the beginning of the time interval.
                 If None, then from the first record
             stop: the end of the time interval. If None, then to the latest record
-            when: condtiion to filter records
+            when: condition to filter records
 
         Keyword Args:
             record_index: if not None, the link will point to a specific record
+                (legacy API < 1.19 only)
+            record_entry: explicit entry name of the record (API >= 1.19)
+            record_timestamp: explicit timestamp of the record (API >= 1.19)
             expire_at: if None, the link will expire in 24 hours
             file_name: file name for download, if None: entry_name_index.bin
             base_url: base URL for the link, if None: use server URL
@@ -692,6 +695,34 @@ class Bucket:  # pylint: disable=too-many-public-methods
         ):
             raise ValueError("record_index must be a non-negative integer")
 
+        has_record_entry = "record_entry" in kwargs
+        has_record_timestamp = "record_timestamp" in kwargs
+        if has_record_entry != has_record_timestamp:
+            if has_record_entry:
+                raise ValueError("record_timestamp must be provided with record_entry")
+            raise ValueError("record_entry must be provided with record_timestamp")
+
+        if has_record_entry and "record_index" in kwargs:
+            raise ValueError(
+                "record_index cannot be used with record_entry/record_timestamp"
+            )
+
+        record_entry = kwargs.get("record_entry")
+        record_timestamp = kwargs.get("record_timestamp")
+        if has_record_timestamp:
+            record_timestamp = unix_timestamp_from_any(record_timestamp)
+            record_index = None
+
+        if (
+            record_index is not None
+            and self._http.api_version is not None
+            and self._http.api_version[1] >= 19
+        ):
+            raise ValueError(
+                "Numeric record index selector was removed from ReductStore v1.19 API "
+                "because it is broken. Use record_entry + record_timestamp."
+            )
+
         expire_at: datetime | None = kwargs.get("expire_at", None)
 
         if expire_at is None:
@@ -705,17 +736,6 @@ class Bucket:  # pylint: disable=too-many-public-methods
             when=when,
             only_metadata=False,
         )
-
-        record_entry = None
-        record_timestamp = None
-        if record_index is not None:
-            record_entry, record_timestamp = await self._resolve_record_identity(
-                entries,
-                record_index,
-                start,
-                stop,
-                when,
-            )
 
         query_link_params = CreateQueryLinkRequest(
             bucket=self.name,
@@ -738,7 +758,11 @@ class Bucket:  # pylint: disable=too-many-public-methods
             (
                 f"{entry}_{record_index}.bin"
                 if record_index is not None
-                else f"{entry}.bin"
+                else (
+                    f"{entry}_{record_timestamp}.bin"
+                    if record_timestamp is not None
+                    else f"{entry}.bin"
+                )
             ),
         )
 
@@ -750,30 +774,6 @@ class Bucket:  # pylint: disable=too-many-public-methods
         )
 
         return CreateQueryLinkResponse.model_validate_json(body).link
-
-    async def _resolve_record_identity(
-        self,
-        entries: str | list[str],
-        record_index: int,
-        start: int | None,
-        stop: int | None,
-        when: dict | None,
-    ) -> tuple[str | None, int | None]:
-        """Resolve an indexed record to exact entry + timestamp identity."""
-
-        current_index = 0
-        async for record in self.query(
-            entries,
-            start=start,
-            stop=stop,
-            when=when,
-            head=True,
-        ):
-            if current_index == record_index:
-                return record.entry, record.timestamp
-            current_index += 1
-
-        return None, None
 
     async def write_attachments(self, entry_name: str, attachments: dict[str, dict]):
         """

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -687,6 +687,52 @@ class Bucket:  # pylint: disable=too-many-public-methods
         start = unix_timestamp_from_any(start) if start else None
         stop = unix_timestamp_from_any(stop) if stop else None
 
+        record_index, record_entry, record_timestamp = self._parse_query_link_selector(
+            kwargs
+        )
+
+        expire_at: datetime | None = kwargs.get("expire_at", None)
+
+        if expire_at is None:
+            expire_at = datetime.now() + timedelta(hours=24)
+
+        query_message = QueryEntry(
+            query_type=QueryType.QUERY,
+            entries=entries if isinstance(entries, list) else [entries],
+            start=start,
+            stop=stop,
+            when=when,
+            only_metadata=False,
+        )
+
+        entry = entries if isinstance(entries, str) else self.name
+
+        file_name = kwargs.get(
+            "file_name",
+            self._query_link_file_name(entry, record_index, record_timestamp),
+        )
+
+        body, _ = await self._http.request_all(
+            "POST",
+            f"/links/{file_name}",
+            data=CreateQueryLinkRequest(
+                bucket=self.name,
+                entry=entries if isinstance(entries, str) else "",
+                index=record_index,
+                record_entry=record_entry,
+                record_timestamp=record_timestamp,
+                query=query_message,
+                expire_at=int(expire_at.timestamp()),
+                base_url=kwargs.get("base_url", None),
+            ).model_dump_json(exclude_none=True),
+            content_type="application/json",
+        )
+
+        return CreateQueryLinkResponse.model_validate_json(body).link
+
+    def _parse_query_link_selector(
+        self, kwargs: dict[str, Any]
+    ) -> tuple[int | None, str | None, int | None]:
         record_index = kwargs.get("record_index", 0)
         if record_index is not None and (
             not isinstance(record_index, int)
@@ -723,57 +769,17 @@ class Bucket:  # pylint: disable=too-many-public-methods
                 "because it is broken. Use record_entry + record_timestamp."
             )
 
-        expire_at: datetime | None = kwargs.get("expire_at", None)
+        return record_index, record_entry, record_timestamp
 
-        if expire_at is None:
-            expire_at = datetime.now() + timedelta(hours=24)
-
-        query_message = QueryEntry(
-            query_type=QueryType.QUERY,
-            entries=entries if isinstance(entries, list) else [entries],
-            start=start,
-            stop=stop,
-            when=when,
-            only_metadata=False,
-        )
-
-        query_link_params = CreateQueryLinkRequest(
-            bucket=self.name,
-            entry=entries if isinstance(entries, str) else "",
-            index=record_index,
-            record_entry=record_entry,
-            record_timestamp=record_timestamp,
-            query=query_message,
-            expire_at=int(expire_at.timestamp()),
-            base_url=kwargs.get("base_url", None),
-        )
-
-        if isinstance(entries, str):
-            entry = entries
-        else:
-            entry = self.name
-
-        file_name = kwargs.get(
-            "file_name",
-            (
-                f"{entry}_{record_index}.bin"
-                if record_index is not None
-                else (
-                    f"{entry}_{record_timestamp}.bin"
-                    if record_timestamp is not None
-                    else f"{entry}.bin"
-                )
-            ),
-        )
-
-        body, _ = await self._http.request_all(
-            "POST",
-            f"/links/{file_name}",
-            data=query_link_params.model_dump_json(exclude_none=True),
-            content_type="application/json",
-        )
-
-        return CreateQueryLinkResponse.model_validate_json(body).link
+    @staticmethod
+    def _query_link_file_name(
+        entry: str, record_index: int | None, record_timestamp: int | None
+    ) -> str:
+        if record_index is not None:
+            return f"{entry}_{record_index}.bin"
+        if record_timestamp is not None:
+            return f"{entry}_{record_timestamp}.bin"
+        return f"{entry}.bin"
 
     async def write_attachments(self, entry_name: str, attachments: dict[str, dict]):
         """

--- a/pkg/reduct/msg/bucket.py
+++ b/pkg/reduct/msg/bucket.py
@@ -154,9 +154,9 @@ class CreateQueryLinkRequest(BaseModel):
     index: Optional[int] = None
     """record index"""
     record_entry: Optional[str] = None
-    """resolved entry name for the indexed record"""
+    """selected record entry name"""
     record_timestamp: Optional[int] = None
-    """resolved UNIX timestamp in microseconds for the indexed record"""
+    """selected UNIX timestamp in microseconds"""
     query: QueryEntry
     """query"""
     expire_at: int = None

--- a/pkg/reduct/version.py
+++ b/pkg/reduct/version.py
@@ -1,3 +1,3 @@
 """Version information for the Reduct package."""
 
-__version__ = "1.19.0"
+__version__ = "1.19.1"

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from typing import List, Tuple
 
@@ -831,6 +831,7 @@ async def test_create_query_link_record_identity_payload(bucket_1, monkeypatch):
 
 @pytest.mark.asyncio
 @requires_api("1.19")
+# pylint: disable=protected-access
 async def test_create_query_link_record_identity_defaults_entry(bucket_1, monkeypatch):
     """Should default record_entry from a single entry selector"""
 

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -796,12 +796,19 @@ async def test_create_query_link_expired(bucket_1):
 @pytest.mark.asyncio
 @requires_api("1.17")
 async def test_create_query_link_record_index(bucket_1):
-    """Should create a query link with record index"""
-    link = await bucket_1.create_query_link("entry-2", record_index=1)
+    """Should handle record index selector according to server API version"""
+    api_minor = bucket_1._http.api_version[1]
+    if api_minor >= 19:
+        with pytest.raises(
+            ValueError,
+            match="Numeric record index selector was removed from ReductStore v1.19 API",
+        ):
+            await bucket_1.create_query_link("entry-2", record_index=1)
+        return
 
+    link = await bucket_1.create_query_link("entry-2", record_index=1)
     resp = requests.get(link, timeout=1.0)
     assert resp.status_code == 200
-
     assert resp.content == b"some-data-4"
     assert resp.headers["content-type"] == "application/octet-stream"
     assert resp.headers["x-reduct-time"] == "4000000"
@@ -811,12 +818,19 @@ async def test_create_query_link_record_index(bucket_1):
 @pytest.mark.asyncio
 @requires_api("1.18")
 async def test_create_query_multi_entry(bucket_1):
-    """Should create a query link with record index for multiple entries"""
-    link = await bucket_1.create_query_link(["entry-1", "entry-2"], record_index=1)
+    """Should handle multi-entry index selector according to server API version"""
+    api_minor = bucket_1._http.api_version[1]
+    if api_minor >= 19:
+        with pytest.raises(
+            ValueError,
+            match="Numeric record index selector was removed from ReductStore v1.19 API",
+        ):
+            await bucket_1.create_query_link(["entry-1", "entry-2"], record_index=1)
+        return
 
+    link = await bucket_1.create_query_link(["entry-1", "entry-2"], record_index=1)
     resp = requests.get(link, timeout=1.0)
     assert resp.status_code == 200
-
     assert resp.content == b"some-data-2"
     assert resp.headers["content-type"] == "application/octet-stream"
     assert resp.headers["x-reduct-time"] == "2000000"
@@ -828,21 +842,31 @@ async def test_create_query_multi_entry(bucket_1):
 @requires_api("1.19")
 # pylint: disable=protected-access
 async def test_create_query_link_record_identity_payload(bucket_1, monkeypatch):
-    """Should include resolved record identity in query link payload"""
+    """Should pass explicit record identity in query link payload"""
 
     captured_payload = {}
     original_request_all = bucket_1._http.request_all
+
+    async def fail_query(*args, **kwargs):
+        raise AssertionError(
+            "create_query_link must not call query() to resolve identity"
+        )
 
     async def request_all_with_capture(method, path, **kwargs):
         if method == "POST" and path.startswith("/links/"):
             captured_payload.update(json.loads(kwargs["data"]))
         return await original_request_all(method, path, **kwargs)
 
+    monkeypatch.setattr(bucket_1, "query", fail_query)
     monkeypatch.setattr(bucket_1._http, "request_all", request_all_with_capture)
 
-    await bucket_1.create_query_link("entry-2", record_index=1)
-
-    assert captured_payload["index"] == 1
+    link = await bucket_1.create_query_link(
+        "entry-2", record_entry="entry-2", record_timestamp=4_000_000
+    )
+    resp = requests.get(link, timeout=1.0)
+    assert resp.status_code == 200
+    assert resp.content == b"some-data-4"
+    assert "index" not in captured_payload
     assert captured_payload["record_entry"] == "entry-2"
     assert captured_payload["record_timestamp"] == 4000000
 

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -766,34 +766,6 @@ async def test_query_extension(bucket_1):
 
 
 @pytest.mark.asyncio
-@requires_api("1.17")
-async def test_create_query_link(bucket_1):
-    """Should create a query link"""
-    link = await bucket_1.create_query_link("entry-2", 3000000)
-
-    resp = requests.get(link, timeout=1.0)
-    assert resp.status_code == 200
-
-    assert resp.content == b"some-data-3"
-    assert resp.headers["content-type"] == "application/octet-stream"
-    assert resp.headers["x-reduct-time"] == "3000000"
-    assert resp.headers["x-reduct-label-number"] == "1"
-
-
-@pytest.mark.asyncio
-@requires_api("1.17")
-async def test_create_query_link_expired(bucket_1):
-    """Should create a query link"""
-    link = await bucket_1.create_query_link(
-        "entry-2", 3000000, expire_at=datetime.now() - timedelta(days=1)
-    )
-
-    resp = requests.get(link, timeout=1.0)
-    assert resp.status_code == 422
-    assert resp.headers["x-reduct-error"] == "Query link has expired"
-
-
-@pytest.mark.asyncio
 @requires_api("1.19")
 async def test_create_query_link_record_identity(bucket_1):
     """Should create a query link with explicit record identity"""
@@ -859,6 +831,37 @@ async def test_create_query_link_record_identity_payload(bucket_1, monkeypatch):
 
 @pytest.mark.asyncio
 @requires_api("1.19")
+async def test_create_query_link_record_identity_defaults_entry(bucket_1, monkeypatch):
+    """Should default record_entry from a single entry selector"""
+
+    captured_payload = {}
+    original_request_all = bucket_1._http.request_all
+
+    async def request_all_with_capture(method, path, **kwargs):
+        if method == "POST" and path.startswith("/links/"):
+            captured_payload.update(json.loads(kwargs["data"]))
+        return await original_request_all(method, path, **kwargs)
+
+    monkeypatch.setattr(bucket_1._http, "request_all", request_all_with_capture)
+
+    link = await bucket_1.create_query_link("entry-2", record_timestamp=4_000_000)
+    resp = requests.get(link, timeout=1.0)
+    assert resp.status_code == 200
+    assert resp.content == b"some-data-4"
+    assert captured_payload["record_entry"] == "entry-2"
+    assert captured_payload["record_timestamp"] == 4000000
+
+    captured_payload.clear()
+    link = await bucket_1.create_query_link(["entry-2"], record_timestamp=4_000_000)
+    resp = requests.get(link, timeout=1.0)
+    assert resp.status_code == 200
+    assert resp.content == b"some-data-4"
+    assert captured_payload["record_entry"] == "entry-2"
+    assert captured_payload["record_timestamp"] == 4000000
+
+
+@pytest.mark.asyncio
+@requires_api("1.19")
 async def test_create_query_link_invalid_record_identity(bucket_1):
     """Should validate explicit record identity arguments"""
 
@@ -870,14 +873,23 @@ async def test_create_query_link_invalid_record_identity(bucket_1):
     with pytest.raises(
         ValueError, match="record_entry must be provided with record_timestamp"
     ):
-        await bucket_1.create_query_link("entry-2", record_timestamp=4_000_000)
+        await bucket_1.create_query_link(
+            ["entry-1", "entry-2"], record_timestamp=4_000_000
+        )
+
+    with pytest.raises(
+        ValueError, match="record_entry must be provided with record_timestamp"
+    ):
+        await bucket_1.create_query_link("entry-*", record_timestamp=4_000_000)
 
 
 @pytest.mark.asyncio
-@requires_api("1.17")
+@requires_api("1.19")
 async def test_create_query_link_filename(bucket_1):
     """Should create a query link with record index"""
-    link = await bucket_1.create_query_link("entry-2", file_name="data.txt")
+    link = await bucket_1.create_query_link(
+        "entry-2", file_name="data.txt", record_timestamp=4_000_000
+    )
     assert "links/data.txt?" in link
 
 

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -794,19 +794,12 @@ async def test_create_query_link_expired(bucket_1):
 
 
 @pytest.mark.asyncio
-@requires_api("1.17")
-async def test_create_query_link_record_index(bucket_1):
-    """Should handle record index selector according to server API version"""
-    api_minor = bucket_1._http.api_version[1]
-    if api_minor >= 19:
-        with pytest.raises(
-            ValueError,
-            match="Numeric record index selector was removed from ReductStore v1.19 API",
-        ):
-            await bucket_1.create_query_link("entry-2", record_index=1)
-        return
-
-    link = await bucket_1.create_query_link("entry-2", record_index=1)
+@requires_api("1.19")
+async def test_create_query_link_record_identity(bucket_1):
+    """Should create a query link with explicit record identity"""
+    link = await bucket_1.create_query_link(
+        "entry-2", record_entry="entry-2", record_timestamp=4_000_000
+    )
     resp = requests.get(link, timeout=1.0)
     assert resp.status_code == 200
     assert resp.content == b"some-data-4"
@@ -816,19 +809,12 @@ async def test_create_query_link_record_index(bucket_1):
 
 
 @pytest.mark.asyncio
-@requires_api("1.18")
+@requires_api("1.19")
 async def test_create_query_multi_entry(bucket_1):
-    """Should handle multi-entry index selector according to server API version"""
-    api_minor = bucket_1._http.api_version[1]
-    if api_minor >= 19:
-        with pytest.raises(
-            ValueError,
-            match="Numeric record index selector was removed from ReductStore v1.19 API",
-        ):
-            await bucket_1.create_query_link(["entry-1", "entry-2"], record_index=1)
-        return
-
-    link = await bucket_1.create_query_link(["entry-1", "entry-2"], record_index=1)
+    """Should create a query link for multiple entries using record identity"""
+    link = await bucket_1.create_query_link(
+        ["entry-1", "entry-2"], record_entry="entry-1", record_timestamp=2_000_000
+    )
     resp = requests.get(link, timeout=1.0)
     assert resp.status_code == 200
     assert resp.content == b"some-data-2"
@@ -872,12 +858,19 @@ async def test_create_query_link_record_identity_payload(bucket_1, monkeypatch):
 
 
 @pytest.mark.asyncio
-@requires_api("1.17")
-async def test_create_query_link_invalid_record_index(bucket_1):
-    """Should validate record index argument"""
+@requires_api("1.19")
+async def test_create_query_link_invalid_record_identity(bucket_1):
+    """Should validate explicit record identity arguments"""
 
-    with pytest.raises(ValueError, match="record_index must be a non-negative integer"):
-        await bucket_1.create_query_link("entry-2", record_index=-1)
+    with pytest.raises(
+        ValueError, match="record_timestamp must be provided with record_entry"
+    ):
+        await bucket_1.create_query_link("entry-2", record_entry="entry-2")
+
+    with pytest.raises(
+        ValueError, match="record_entry must be provided with record_timestamp"
+    ):
+        await bucket_1.create_query_link("entry-2", record_timestamp=4_000_000)
 
 
 @pytest.mark.asyncio

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -67,7 +67,7 @@ async def test__info(client):
     assert info.bucket_count >= 2
     assert info.usage >= 374
     assert info.oldest_record == 1_000_000
-    assert info.latest_record == 6_000_000
+    assert info.latest_record >= 6_000_000
 
     defaults = info.defaults.bucket.model_dump()
     assert defaults["max_block_size"] == 64000000


### PR DESCRIPTION
Closes #166

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Removed client-side record identity resolution from `Bucket.create_query_link`.
- Aligned behavior with `reduct-js`:
  - `record_index` remains legacy and is accepted only for API `< 1.19`.
  - For API `>= 1.19`, numeric `record_index` now raises an explicit `ValueError`.
  - Added explicit `record_entry` + `record_timestamp` selector support.
- Added selector validation:
  - reject partial identity (`record_entry` without `record_timestamp` and vice versa),
  - reject mixing `record_index` with explicit identity.
- Removed `_resolve_record_identity` helper that queried records internally.
- Updated query-link filename default to include `record_timestamp` when explicit identity is used.
- Updated integration tests to cover legacy/API-v1.19 behavior split and assert no internal query happens for explicit identity.

### Related issues

- #166

### Does this PR introduce a breaking change?

Yes for API v1.19+ users who still pass `record_index`: the call now raises `ValueError` and users must pass `record_entry` + `record_timestamp`.

### Other information:

- `black` was run on changed files.
- `python -m compileall` passes for changed modules.
- Integration tests require ReductStore at `http://127.0.0.1:8383` and were not run in this environment.
