### PR TITLE
Harden CI GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #169

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

CI/security hardening

### What was changed?

- Added a workflow-level default permission block to `.github/workflows/ci.yml`:
  - `permissions:`
    - `contents: read`
- This makes `GITHUB_TOKEN` least-privilege by default for all jobs in this workflow.
- No job in this workflow currently requires `contents: write` or `id-token: write`, so no elevated job-level permissions were added.

### Related issues

- https://github.com/reductstore/reduct-py/issues/169
- Parent tracker: https://github.com/reductstore/security/issues/16

### Does this PR introduce a breaking change?

No breaking runtime/API changes. This only narrows CI token permissions.

### Other information:

Implementation follows the approved plan in issue comment:
https://github.com/reductstore/reduct-py/issues/169#issuecomment-4351537744
