### PR TITLE
Pin third-party GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Dump docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
         with:
           dest: './logs'
       - name: Tar logs
@@ -160,7 +160,7 @@ jobs:
           name: package
           path: ./dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295 # v1.5.0
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip setuptools wheel
 
@@ -28,7 +28,7 @@ jobs:
     needs: format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip pipx
 
@@ -44,16 +44,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip pipx
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@master
         with:
           name: package
           path: ./dist
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python}}
 
@@ -79,12 +79,12 @@ jobs:
         reductstore_version: ["latest", "main"]
         token: ["", "ACCESS_TOKEN"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@master
         with:
           name: package
           path: ./dist
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python}}
 
@@ -122,7 +122,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@master
         with:
           name: package
@@ -153,7 +153,7 @@ jobs:
 
     if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v6
 
       - uses: actions/download-artifact@master
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support non-JSON content types in `write_attachments` and `read_attachments`, [PR-173](https://github.com/reductstore/reduct-py/pull/173)
 
+### Changed
+
+- Pin third-party GitHub Actions in CI workflows to immutable commit SHAs for SSDLC hardening, [PR-174](https://github.com/reductstore/reduct-py/pull/174)
+
 ## 1.19.1 - 2026-04-20
 
 ### Fixed


### PR DESCRIPTION
Closes #171

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security / CI hardening.

### What was changed?

- Pinned third-party GitHub Actions to immutable commit SHAs in `.github/workflows/ci.yml`:
  - `jwalton/gh-docker-logs@v2` → `jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e`
  - `pypa/gh-action-pypi-publish@v1.5.0` → `pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295`
- Added inline comments preserving the original tag references for readability.

### Related issues

- https://github.com/reductstore/reduct-py/issues/171
- Parent tracking: https://github.com/reductstore/security/issues/22
- Plan comment: https://github.com/reductstore/reduct-py/issues/171#issuecomment-4396369716

### Does this PR introduce a breaking change?

No breaking runtime/API changes. Workflow behavior should remain equivalent while reducing supply-chain risk from mutable refs.

### Other information:

- Repository-level tests were not run locally because this change only updates GitHub workflow action refs; validation is expected via CI on this PR.
