### PR TITLE
chore(ci): switch PyPI publishing to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
     name: Upload if release
     needs: [ pylint, test, run_examples ]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     defaults:
       run:
         working-directory: ./python
@@ -160,7 +162,4 @@ jobs:
           name: package
           path: ./dist
 
-      - uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295 # v1.5.0
-        with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Switch PyPI publishing workflow to Trusted Publishers (OIDC) and drop static credential inputs, [PR-178](https://github.com/reductstore/reduct-py/pull/178)
 - Add lifecycle policy API support, [PR-176](https://github.com/reductstore/reduct-py/pull/176)
 - Pin third-party GitHub Actions in CI workflows to immutable commit SHAs for SSDLC hardening, [PR-174](https://github.com/reductstore/reduct-py/pull/174)
 


### PR DESCRIPTION
Closes #177

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

CI/security hardening change for PyPI publishing.

### What was changed?

- Switched the release publish job from username/password auth to PyPI Trusted Publisher (OIDC).
- Added job-level `permissions: id-token: write` for `py-pip-upload`.
- Updated `pypa/gh-action-pypi-publish` to pinned `v1.14.0` (`cef221092ed1bacb1cc03d23a2d87d1d172e277b`).
- Removed legacy `PYPI_USERNAME` / `PYPI_PASSWORD` inputs from the publish step.

### Related issues

- https://github.com/reductstore/reduct-py/issues/177
- Plan comment: https://github.com/reductstore/reduct-py/issues/177#issuecomment-4554776562

### Does this PR introduce a breaking change?

No runtime/API change for SDK users. Release workflow authentication changes from static secrets to GitHub OIDC trusted publishing.

### Other information:

Local validation run:

- `black . --check` ✅
- `pylint pkg/reduct tests` ✅
- `pytest tests` against `reduct/store:latest` ✅ (`100 passed, 26 skipped`)
- `pytest tests` against `reduct/store:main` ⚠️ hit pre-existing failures in `tests/bucket_test.py` (`test_create_query_*` returning older records); unrelated to this workflow-only change.

Post-merge operational step:

- After first successful tag publish via OIDC, remove legacy `PYPI_USERNAME` and `PYPI_PASSWORD` repository secrets.
