### PR TITLE
Add replication destination prefix support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add replication destination prefix setting support, [PR-185](https://github.com/reductstore/reduct-py/pull/185)
+
 ## 1.20.0 - 2026-06-16
 
 ### Changed

--- a/pkg/reduct/client.py
+++ b/pkg/reduct/client.py
@@ -35,6 +35,13 @@ from reduct.msg.token import (
 )
 
 
+def _replication_settings_to_json(settings: ReplicationSettings) -> str:
+    if settings.dst_prefix == "":
+        return settings.model_dump_json(exclude={"dst_prefix"})
+
+    return settings.model_dump_json()
+
+
 class Client:  # pylint: disable=too-many-public-methods
     """HTTP Client for Reduct Storage HTTP API"""
 
@@ -281,7 +288,7 @@ class Client:  # pylint: disable=too-many-public-methods
         Raises:
             ReductError: if there is an HTTP error
         """
-        data = settings.model_dump_json()
+        data = _replication_settings_to_json(settings)
         await self._http.request_all(
             "POST", f"/replications/{replication_name}", data=data
         )
@@ -297,7 +304,7 @@ class Client:  # pylint: disable=too-many-public-methods
         Raises:
             ReductError: if there is an HTTP error
         """
-        data = settings.model_dump_json()
+        data = _replication_settings_to_json(settings)
         await self._http.request_all(
             "PUT", f"/replications/{replication_name}", data=data
         )

--- a/pkg/reduct/client.py
+++ b/pkg/reduct/client.py
@@ -35,13 +35,6 @@ from reduct.msg.token import (
 )
 
 
-def _replication_settings_to_json(settings: ReplicationSettings) -> str:
-    if settings.dst_prefix == "":
-        return settings.model_dump_json(exclude={"dst_prefix"})
-
-    return settings.model_dump_json()
-
-
 class Client:  # pylint: disable=too-many-public-methods
     """HTTP Client for Reduct Storage HTTP API"""
 
@@ -288,7 +281,7 @@ class Client:  # pylint: disable=too-many-public-methods
         Raises:
             ReductError: if there is an HTTP error
         """
-        data = _replication_settings_to_json(settings)
+        data = settings.model_dump_json()
         await self._http.request_all(
             "POST", f"/replications/{replication_name}", data=data
         )
@@ -304,7 +297,7 @@ class Client:  # pylint: disable=too-many-public-methods
         Raises:
             ReductError: if there is an HTTP error
         """
-        data = _replication_settings_to_json(settings)
+        data = settings.model_dump_json()
         await self._http.request_all(
             "PUT", f"/replications/{replication_name}", data=data
         )

--- a/pkg/reduct/msg/replication.py
+++ b/pkg/reduct/msg/replication.py
@@ -77,6 +77,8 @@ class ReplicationSettings(BaseModel):
     entries: List[str] = Field([])
     """list of entries to replicate. If empty, all entries are replicated.
     Wildcards are supported"""
+    dst_prefix: str = ""
+    """prefix to add to destination entry names"""
     when: Optional[Dict] = None
     """replication schedule in cron format"""
     mode: ReplicationMode = ReplicationMode.ENABLED

--- a/tests/replication_test.py
+++ b/tests/replication_test.py
@@ -1,5 +1,8 @@
 """Tests for replication endpoints"""
 
+import json
+from contextlib import suppress
+
 import pytest
 from reduct import (
     ReductError,
@@ -8,7 +11,60 @@ from reduct import (
     ReplicationMode,
     ReplicationSettings,
 )
+from reduct.client import _replication_settings_to_json
 from tests.conftest import requires_api
+
+
+async def _delete_replication_if_exists(client, replication_name):
+    with suppress(ReductError):
+        await client.delete_replication(replication_name)
+
+
+def test__replication_settings_prefix_serialization():
+    """Test serializing replication settings with prefix"""
+    settings = ReplicationSettings(
+        src_bucket="src",
+        dst_bucket="dst",
+        dst_host="http://127.0.0.1:8383",
+        dst_prefix="robot-1",
+    )
+    payload = json.loads(_replication_settings_to_json(settings))
+
+    assert payload["dst_prefix"] == "robot-1"
+
+
+def test__replication_settings_omits_empty_prefix():
+    """Test omitting empty prefix from replication settings payload"""
+    settings = ReplicationSettings(
+        src_bucket="src",
+        dst_bucket="dst",
+        dst_host="http://127.0.0.1:8383",
+    )
+    payload = json.loads(_replication_settings_to_json(settings))
+
+    assert "dst_prefix" not in payload
+
+
+def test__replication_settings_prefix_deserialization():
+    """Test parsing replication settings with and without prefix"""
+    settings = ReplicationSettings.model_validate(
+        {
+            "src_bucket": "src",
+            "dst_bucket": "dst",
+            "dst_host": "http://127.0.0.1:8383",
+            "dst_prefix": "robot-1",
+        }
+    )
+    older_settings = ReplicationSettings.model_validate(
+        {
+            "src_bucket": "src",
+            "dst_bucket": "dst",
+            "dst_host": "http://127.0.0.1:8383",
+        }
+    )
+
+    assert settings.dst_prefix == "robot-1"
+    assert older_settings.dst_prefix == ""
 
 
 @pytest.mark.asyncio
@@ -77,6 +133,33 @@ async def test__replication_with_when(client, random_prefix, bucket_1, bucket_2)
     replication = await client.get_replication_detail(replication_name)
 
     assert replication.settings.when == {"&number": {"$gt": 1}}
+
+
+@pytest.mark.asyncio
+@requires_api("1.21")
+async def test__replication_with_prefix(client, random_prefix, bucket_1, bucket_2):
+    """Test creating and updating a replication with destination prefix"""
+    replication_name = f"{random_prefix}-replication-prefix"
+    settings = ReplicationSettings(
+        src_bucket=bucket_1.name,
+        dst_bucket=bucket_2.name,
+        dst_host="http://127.0.0.1:8383",
+        dst_prefix="robot-1",
+    )
+
+    try:
+        await client.create_replication(replication_name, settings)
+        replication = await client.get_replication_detail(replication_name)
+
+        assert replication.settings.dst_prefix == "robot-1"
+
+        settings.dst_prefix = "line-a"
+        await client.update_replication(replication_name, settings)
+        replication = await client.get_replication_detail(replication_name)
+
+        assert replication.settings.dst_prefix == "line-a"
+    finally:
+        await _delete_replication_if_exists(client, replication_name)
 
 
 @pytest.mark.asyncio

--- a/tests/replication_test.py
+++ b/tests/replication_test.py
@@ -1,6 +1,5 @@
 """Tests for replication endpoints"""
 
-import json
 from contextlib import suppress
 
 import pytest
@@ -11,60 +10,12 @@ from reduct import (
     ReplicationMode,
     ReplicationSettings,
 )
-from reduct.client import _replication_settings_to_json
 from tests.conftest import requires_api
 
 
 async def _delete_replication_if_exists(client, replication_name):
     with suppress(ReductError):
         await client.delete_replication(replication_name)
-
-
-def test__replication_settings_prefix_serialization():
-    """Test serializing replication settings with prefix"""
-    settings = ReplicationSettings(
-        src_bucket="src",
-        dst_bucket="dst",
-        dst_host="http://127.0.0.1:8383",
-        dst_prefix="robot-1",
-    )
-    payload = json.loads(_replication_settings_to_json(settings))
-
-    assert payload["dst_prefix"] == "robot-1"
-
-
-def test__replication_settings_omits_empty_prefix():
-    """Test omitting empty prefix from replication settings payload"""
-    settings = ReplicationSettings(
-        src_bucket="src",
-        dst_bucket="dst",
-        dst_host="http://127.0.0.1:8383",
-    )
-    payload = json.loads(_replication_settings_to_json(settings))
-
-    assert "dst_prefix" not in payload
-
-
-def test__replication_settings_prefix_deserialization():
-    """Test parsing replication settings with and without prefix"""
-    settings = ReplicationSettings.model_validate(
-        {
-            "src_bucket": "src",
-            "dst_bucket": "dst",
-            "dst_host": "http://127.0.0.1:8383",
-            "dst_prefix": "robot-1",
-        }
-    )
-    older_settings = ReplicationSettings.model_validate(
-        {
-            "src_bucket": "src",
-            "dst_bucket": "dst",
-            "dst_host": "http://127.0.0.1:8383",
-        }
-    )
-
-    assert settings.dst_prefix == "robot-1"
-    assert older_settings.dst_prefix == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #184

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Add `ReplicationSettings.dst_prefix` for the replication destination entry prefix field used by ReductStore core.
- Use the existing Pydantic model serialization directly for create/update replication payloads.
- Add an API v1.21-gated integration test that creates, reads, updates, and reads back `dst_prefix` against `reduct/store:main`.

Note: the SDK issue text still says `prefix`, but the final core PR naming review changed the HTTP/model field to `dst_prefix` and provisioning to `RS_REPLICATION_<ID>_DST_PREFIX`. This implementation follows the merged server API and the Rust SDK PR for the same feature.

### Related issues

- https://github.com/reductstore/reduct-py/issues/184
- https://github.com/reductstore/reductstore/issues/1487
- https://github.com/reductstore/reductstore/pull/1486
- https://github.com/reductstore/reduct-rs/pull/94

### Does this PR introduce a breaking change?

No. The public API change is additive. Existing callers do not need to set `dst_prefix`, and stable ReductStore compatibility is covered by the test suite.

### Other information:

Local validation after addressing review:

- `.venv/bin/black . --check`
- `.venv/bin/pylint pkg/reduct tests`
- `PYTHONPATH=. RS_API_TOKEN=ACCESS_TOKEN .venv/bin/pytest tests` against `reduct/store:latest`
- `PYTHONPATH=. RS_API_TOKEN=ACCESS_TOKEN .venv/bin/pytest tests` against `reduct/store:main`
- `.venv/bin/python -m build --wheel`