### PR TITLE
Add replication compression setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add replication compression setting support, [PR-187](https://github.com/reductstore/reduct-py/pull/187)
 - Add replication destination prefix setting support, [PR-185](https://github.com/reductstore/reduct-py/pull/185)
 
 ## 1.20.0 - 2026-06-16

--- a/pkg/reduct/__init__.py
+++ b/pkg/reduct/__init__.py
@@ -17,6 +17,7 @@ from reduct.msg.replication import (
     ReplicationDetailInfo,
     ReplicationSettings,
     ReplicationMode,
+    ReplicationCompression,
 )
 
 from reduct.msg.lifecycle import (

--- a/pkg/reduct/msg/replication.py
+++ b/pkg/reduct/msg/replication.py
@@ -14,6 +14,14 @@ class ReplicationMode(str, Enum):
     DISABLED = "disabled"
 
 
+class ReplicationCompression(str, Enum):
+    """Replication batch payload compression"""
+
+    NONE = "none"
+    ZSTD = "zstd"
+    GZIP = "gzip"
+
+
 class ReplicationInfo(BaseModel):
     """Replication information"""
 
@@ -83,6 +91,8 @@ class ReplicationSettings(BaseModel):
     """replication schedule in cron format"""
     mode: ReplicationMode = ReplicationMode.ENABLED
     """replication mode"""
+    compression: ReplicationCompression = ReplicationCompression.NONE
+    """replication batch payload compression"""
 
 
 class ReplicationDetailInfo(BaseModel):

--- a/tests/replication_test.py
+++ b/tests/replication_test.py
@@ -1,6 +1,5 @@
 """Tests for replication endpoints"""
 
-import json
 from contextlib import suppress
 
 import pytest
@@ -18,57 +17,6 @@ from tests.conftest import requires_api
 async def _delete_replication_if_exists(client, replication_name):
     with suppress(ReductError):
         await client.delete_replication(replication_name)
-
-
-def test__replication_settings_serializes_compression():
-    """Test replication compression model serialization"""
-    default_settings = ReplicationSettings(
-        src_bucket="src",
-        dst_bucket="dst",
-        dst_host="http://127.0.0.1:8383",
-    )
-    assert default_settings.compression == ReplicationCompression.NONE
-    assert json.loads(default_settings.model_dump_json())["compression"] == "none"
-
-    compressed_settings = ReplicationSettings(
-        src_bucket="src",
-        dst_bucket="dst",
-        dst_host="http://127.0.0.1:8383",
-        compression=ReplicationCompression.ZSTD,
-    )
-    assert json.loads(compressed_settings.model_dump_json())["compression"] == "zstd"
-
-
-def test__replication_detail_deserializes_compression():
-    """Test replication compression model deserialization"""
-    replication_detail = ReplicationDetailInfo.model_validate_json(
-        json.dumps(
-            {
-                "diagnostics": {
-                    "hourly": {
-                        "ok": 0,
-                        "errored": 0,
-                        "errors": {},
-                    },
-                },
-                "info": {
-                    "name": "camera-sync",
-                    "is_provisioned": False,
-                    "is_active": False,
-                    "mode": "enabled",
-                    "pending_records": 0,
-                },
-                "settings": {
-                    "src_bucket": "src",
-                    "dst_bucket": "dst",
-                    "dst_host": "http://127.0.0.1:8383",
-                    "compression": "gzip",
-                },
-            }
-        )
-    )
-
-    assert replication_detail.settings.compression == ReplicationCompression.GZIP
 
 
 @pytest.mark.asyncio

--- a/tests/replication_test.py
+++ b/tests/replication_test.py
@@ -1,10 +1,12 @@
 """Tests for replication endpoints"""
 
+import json
 from contextlib import suppress
 
 import pytest
 from reduct import (
     ReductError,
+    ReplicationCompression,
     ReplicationDetailInfo,
     ReplicationInfo,
     ReplicationMode,
@@ -16,6 +18,57 @@ from tests.conftest import requires_api
 async def _delete_replication_if_exists(client, replication_name):
     with suppress(ReductError):
         await client.delete_replication(replication_name)
+
+
+def test__replication_settings_serializes_compression():
+    """Test replication compression model serialization"""
+    default_settings = ReplicationSettings(
+        src_bucket="src",
+        dst_bucket="dst",
+        dst_host="http://127.0.0.1:8383",
+    )
+    assert default_settings.compression == ReplicationCompression.NONE
+    assert json.loads(default_settings.model_dump_json())["compression"] == "none"
+
+    compressed_settings = ReplicationSettings(
+        src_bucket="src",
+        dst_bucket="dst",
+        dst_host="http://127.0.0.1:8383",
+        compression=ReplicationCompression.ZSTD,
+    )
+    assert json.loads(compressed_settings.model_dump_json())["compression"] == "zstd"
+
+
+def test__replication_detail_deserializes_compression():
+    """Test replication compression model deserialization"""
+    replication_detail = ReplicationDetailInfo.model_validate_json(
+        json.dumps(
+            {
+                "diagnostics": {
+                    "hourly": {
+                        "ok": 0,
+                        "errored": 0,
+                        "errors": {},
+                    },
+                },
+                "info": {
+                    "name": "camera-sync",
+                    "is_provisioned": False,
+                    "is_active": False,
+                    "mode": "enabled",
+                    "pending_records": 0,
+                },
+                "settings": {
+                    "src_bucket": "src",
+                    "dst_bucket": "dst",
+                    "dst_host": "http://127.0.0.1:8383",
+                    "compression": "gzip",
+                },
+            }
+        )
+    )
+
+    assert replication_detail.settings.compression == ReplicationCompression.GZIP
 
 
 @pytest.mark.asyncio
@@ -109,6 +162,33 @@ async def test__replication_with_prefix(client, random_prefix, bucket_1, bucket_
         replication = await client.get_replication_detail(replication_name)
 
         assert replication.settings.dst_prefix == "line-a"
+    finally:
+        await _delete_replication_if_exists(client, replication_name)
+
+
+@pytest.mark.asyncio
+@requires_api("1.21")
+async def test__replication_with_compression(client, random_prefix, bucket_1, bucket_2):
+    """Test creating and updating a replication with compression"""
+    replication_name = f"{random_prefix}-replication-compression"
+    settings = ReplicationSettings(
+        src_bucket=bucket_1.name,
+        dst_bucket=bucket_2.name,
+        dst_host="http://127.0.0.1:8383",
+        compression=ReplicationCompression.ZSTD,
+    )
+
+    try:
+        await client.create_replication(replication_name, settings)
+        replication = await client.get_replication_detail(replication_name)
+
+        assert replication.settings.compression == ReplicationCompression.ZSTD
+
+        settings.compression = ReplicationCompression.GZIP
+        await client.update_replication(replication_name, settings)
+        replication = await client.get_replication_detail(replication_name)
+
+        assert replication.settings.compression == ReplicationCompression.GZIP
     finally:
         await _delete_replication_if_exists(client, replication_name)
 


### PR DESCRIPTION
Closes #186

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Added `ReplicationCompression` with `none`, `zstd`, and `gzip` values.
- Added `ReplicationSettings.compression`, defaulting to `ReplicationCompression.NONE` for backward compatibility.
- Re-exported `ReplicationCompression` from `reduct`.
- Added an API `1.21+` integration test that creates a replication with `zstd`, updates it to `gzip`, and reads both values back.

Implementation follows the approved plan:
https://github.com/reductstore/reduct-py/issues/186#issuecomment-4967619848

### Related issues

- Parent rollout: reductstore/reductstore#1547
- Core implementation: reductstore/reductstore#1538
- Original feature request: reductstore/reductstore#1348

### Does this PR introduce a breaking change?

No. Existing callers that omit `compression` keep the default `none` behavior.

### Other information:

Local validation:

- `pytest tests` against `reduct/store:main` API `1.21`: 118 passed, 10 skipped.
- `pytest tests` against `reduct/store:latest` API `1.20`: 116 passed, 12 skipped; the compression integration is version-gated and skipped there.
- `black . --check`
- `pylint pkg/reduct tests`
- `python -m build --wheel`


